### PR TITLE
Add methods to FIFO Queue

### DIFF
--- a/error.go
+++ b/error.go
@@ -7,6 +7,8 @@ const (
 	QueueErrorCodeFullCapacity          = "full-capacity"
 	QueueErrorCodeInternalChannelClosed = "internal-channel-closed"
 	QueueErrorCodeIndexesMatch          = "indexes-match"
+	QueueErrorCodeIndexFirstPosition    = "index-first-position"
+	QueueErrorCodeIndexLastPosition     = "index-last-position"
 )
 
 type QueueError struct {

--- a/error.go
+++ b/error.go
@@ -6,6 +6,7 @@ const (
 	QueueErrorCodeIndexOutOfBounds      = "index-out-of-bounds"
 	QueueErrorCodeFullCapacity          = "full-capacity"
 	QueueErrorCodeInternalChannelClosed = "internal-channel-closed"
+	QueueErrorCodeIndexesMatch          = "indexes-match"
 )
 
 type QueueError struct {

--- a/fifo_queue.go
+++ b/fifo_queue.go
@@ -76,8 +76,8 @@ func (st *FIFO) Dequeue() (interface{}, error) {
 	st.rwmutex.Lock()
 	defer st.rwmutex.Unlock()
 
-	len := len(st.slice)
-	if len == 0 {
+	length := len(st.slice)
+	if length == 0 {
 		return nil, NewQueueError(QueueErrorCodeEmptyQueue, "empty queue")
 	}
 
@@ -218,4 +218,31 @@ func (st *FIFO) IsLocked() bool {
 	defer st.lockRWmutex.RUnlock()
 
 	return st.isLocked
+}
+
+// Swap swaps values from position a to position b and vice versa.
+func (st *FIFO) Swap(a int, b int) *QueueError {
+	if st.isLocked {
+		return NewQueueError(QueueErrorCodeLockedQueue, "The queue is locked")
+	}
+
+	st.rwmutex.Lock()
+	defer st.rwmutex.Unlock()
+
+	length := len(st.slice)
+	if length == 0 {
+		return NewQueueError(QueueErrorCodeEmptyQueue, "Empty queue")
+	}
+
+	if a == b {
+		return NewQueueError(QueueErrorCodeIndexesMatch, "Indexes are the same number")
+	}
+
+	if a >= length || b >= length {
+		return NewQueueError(QueueErrorCodeIndexOutOfBounds, "Index out of bounds")
+	}
+
+	st.slice[a], st.slice[b] = st.slice[b], st.slice[a]
+
+	return nil
 }

--- a/fifo_queue.go
+++ b/fifo_queue.go
@@ -246,3 +246,67 @@ func (st *FIFO) Swap(a int, b int) *QueueError {
 
 	return nil
 }
+
+// MoveFrontWithId moves the element at index position to the front of the queue
+func (st *FIFO) MoveFrontWithId(index int) error {
+
+	if st.isLocked {
+		return NewQueueError(QueueErrorCodeLockedQueue, "The queue is locked")
+	}
+	st.rwmutex.Lock()
+	defer st.rwmutex.Unlock()
+
+	length := len(st.slice)
+	if length == 0 {
+		return NewQueueError(QueueErrorCodeEmptyQueue, "Empty queue")
+	}
+
+	if index == 0 {
+		return NewQueueError(QueueErrorCodeIndexFirstPosition, "Element already is in first position")
+	}
+
+	if index >= length {
+		return NewQueueError(QueueErrorCodeIndexOutOfBounds, "Index is out of bounds")
+	}
+
+	// Moves the element all the way to the back of the queue.
+	// The element is moved one position at a time using bubble sort algorithm.
+	for i := index; i >= 1; i-- {
+		st.slice[i], st.slice[i-1] = st.slice[i-1], st.slice[i]
+	}
+
+	return nil
+}
+
+// MoveBackWithId moves the element at index position to the back of the queue
+func (st *FIFO) MoveBackWithId(index int) error {
+
+	if st.isLocked {
+		return NewQueueError(QueueErrorCodeLockedQueue, "The queue is locked")
+	}
+	st.rwmutex.Lock()
+	defer st.rwmutex.Unlock()
+
+	length := len(st.slice)
+	if length == 0 {
+		return NewQueueError(QueueErrorCodeEmptyQueue, "Empty queue")
+	}
+
+	if index == length-1 {
+		return NewQueueError(QueueErrorCodeIndexLastPosition, "Element already is in last position")
+	}
+
+	if index >= length {
+		return NewQueueError(QueueErrorCodeIndexOutOfBounds, "Index is out of bounds")
+	}
+
+	// Moves the element all the way to the front of the queue.
+	// The element is moved one position at a time using bubble sort algorithm.
+	for i := index; i < length-1; i++ {
+		st.slice[i], st.slice[i+1] = st.slice[i+1], st.slice[i]
+	}
+
+	return nil
+}
+
+

--- a/fifo_queue_test.go
+++ b/fifo_queue_test.go
@@ -28,8 +28,8 @@ func (suite *FIFOTestSuite) SetupTest() {
 
 // no elements at initialization
 func (suite *FIFOTestSuite) TestNoElementsAtInitialization() {
-	len := suite.fifo.GetLen()
-	suite.Equalf(0, len, "No elements expected at initialization, currently: %v", len)
+	length := suite.fifo.GetLen()
+	suite.Equalf(0, length, "No elements expected at initialization, currently: %v", length)
 }
 
 // unlocked at initialization
@@ -59,12 +59,12 @@ func (suite *FIFOTestSuite) TestEnqueueLockSingleGR() {
 // single enqueue (1 element, 1 goroutine)
 func (suite *FIFOTestSuite) TestEnqueueLenSingleGR() {
 	suite.fifo.Enqueue(testValue)
-	len := suite.fifo.GetLen()
-	suite.Equalf(1, len, "Expected number of elements in queue: 1, currently: %v", len)
+	length := suite.fifo.GetLen()
+	suite.Equalf(1, length, "Expected number of elements in queue: 1, currently: %v", length)
 
 	suite.fifo.Enqueue(5)
-	len = suite.fifo.GetLen()
-	suite.Equalf(2, len, "Expected number of elements in queue: 2, currently: %v", len)
+	length = suite.fifo.GetLen()
+	suite.Equalf(2, length, "Expected number of elements in queue: 2, currently: %v", length)
 }
 
 // single enqueue and wait for next element
@@ -382,15 +382,15 @@ func (suite *FIFOTestSuite) TestDequeueSingleGR() {
 	val, err := suite.fifo.Dequeue()
 	suite.NoError(err, "Unexpected error")
 	suite.Equal(testValue, val, "Wrong element's value")
-	len := suite.fifo.GetLen()
-	suite.Equal(1, len, "Incorrect number of queue elements")
+	length := suite.fifo.GetLen()
+	suite.Equal(1, length, "Incorrect number of queue elements")
 
 	// get the second element
 	val, err = suite.fifo.Dequeue()
 	suite.NoError(err, "Unexpected error")
 	suite.Equal(5, val, "Wrong element's value")
-	len = suite.fifo.GetLen()
-	suite.Equal(0, len, "Incorrect number of queue elements")
+	length = suite.fifo.GetLen()
+	suite.Equal(0, length, "Incorrect number of queue elements")
 
 }
 
@@ -453,7 +453,7 @@ func (suite *FIFOTestSuite) TestDequeueOrWaitForNextElementLockSingleGR() {
 // single GR DequeueOrWaitForNextElement with a previous enqueued element
 func (suite *FIFOTestSuite) TestDequeueOrWaitForNextElementWithEnqueuedElementSingleGR() {
 	value := 100
-	len := suite.fifo.GetLen()
+	length := suite.fifo.GetLen()
 	suite.fifo.Enqueue(value)
 
 	result, err := suite.fifo.DequeueOrWaitForNextElement()
@@ -461,7 +461,7 @@ func (suite *FIFOTestSuite) TestDequeueOrWaitForNextElementWithEnqueuedElementSi
 	suite.NoError(err)
 	suite.Equal(value, result)
 	// length must be exactly the same as it was before
-	suite.Equal(len, suite.fifo.GetLen())
+	suite.Equal(length, suite.fifo.GetLen())
 }
 
 // single GR DequeueOrWaitForNextElement 1 element
@@ -678,6 +678,76 @@ func (suite *FIFOTestSuite) TestIsLockedSingleGR() {
 
 	suite.fifo.Unlock()
 	suite.True(suite.fifo.isLocked == suite.fifo.IsLocked(), "fifo.IsLocked() has to be equal to fifo.isLocked")
+}
+
+// ***************************************************************************************
+// ** Swap
+// ***************************************************************************************
+func (suite *FIFOTestSuite) TestSwapEmptyQueue() {
+	const (
+		a = 4
+		b = 4
+	)
+
+	err := suite.fifo.Swap(a, b)
+
+	suite.EqualError(err, "Empty queue")
+}
+
+func (suite *FIFOTestSuite) TestSwapIndexOutOfBounds() {
+	const (
+		size = 2
+		a    = 4
+		b    = 3
+	)
+
+	for i := 0; i < size; i++ {
+		suite.fifo.Enqueue(i)
+	}
+
+	err := suite.fifo.Swap(a, b)
+
+	suite.EqualError(err, "Index out of bounds")
+}
+
+func (suite *FIFOTestSuite) TestSwapSameIndex() {
+	const (
+		size = 10
+		a    = 4
+		b    = 4
+	)
+
+	for i := 0; i < size; i++ {
+		suite.fifo.Enqueue(i)
+	}
+
+	err := suite.fifo.Swap(a, b)
+
+	suite.EqualError(err, "Indexes are the same number")
+}
+
+func (suite *FIFOTestSuite) TestSwapElements() {
+
+	const (
+		size = 10
+		a    = 3
+		b    = 4
+	)
+
+	for i := 0; i < size; i++ {
+		suite.fifo.Enqueue(i)
+	}
+
+	oldValueFromA, _ := suite.fifo.Get(a)
+	oldValueFromB, _ := suite.fifo.Get(b)
+
+	suite.fifo.Swap(a, b)
+
+	newValueFromA, _ := suite.fifo.Get(a)
+	newValueFromB, _ := suite.fifo.Get(b)
+
+	suite.Equal(oldValueFromA, newValueFromB)
+	suite.Equal(oldValueFromB, newValueFromA)
 }
 
 // ***************************************************************************************

--- a/fifo_queue_test.go
+++ b/fifo_queue_test.go
@@ -855,6 +855,86 @@ func (suite *FIFOTestSuite) TestMoveBackAlreadyInBack() {
 }
 
 // ***************************************************************************************
+// ** Get all elements
+// ***************************************************************************************
+func (suite *FIFOTestSuite) TestGetAll() {
+	const (
+		size = 10
+	)
+	var slice []interface{}
+	for i := 0; i < size; i++ {
+		suite.fifo.Enqueue(i)
+		slice = append(slice, i)
+	}
+	result, err := suite.fifo.GetAll(nil, nil)
+	suite.NoError(err)
+	suite.Equal(slice, result)
+}
+
+func (suite *FIFOTestSuite) TestGetAllFiltered() {
+	const (
+		size = 10
+
+	)
+	var (
+		limit = 2
+		offset = 4
+	)
+	var slice []interface{}
+	for i := 0; i < size; i++ {
+		suite.fifo.Enqueue(i)
+		slice = append(slice, i)
+	}
+
+	expected := []interface{}{5, 6}
+
+	result, err := suite.fifo.GetAll(&limit, &offset)
+	suite.NoError(err)
+	suite.Equal(slice, suite.fifo.slice)
+	suite.Equal(expected, result)
+}
+
+func (suite *FIFOTestSuite) TestGetAllFilteredOutOfBounds() {
+	const (
+		size = 10
+
+	)
+	var (
+		limit = 2
+		offset = 10
+	)
+	var slice []interface{}
+	for i := 0; i < size; i++ {
+		suite.fifo.Enqueue(i)
+		slice = append(slice, i)
+	}
+
+	_, err := suite.fifo.GetAll(&limit, &offset)
+	suite.EqualError(err, "Offset index out of bounds")
+	suite.Equal(slice, suite.fifo.slice)
+}
+
+func (suite *FIFOTestSuite) TestGetAllFilteredWrongRange() {
+	const (
+		size = 10
+
+	)
+	var (
+		limit = -5
+		offset = -3
+	)
+	var slice []interface{}
+	for i := 0; i < size; i++ {
+		suite.fifo.Enqueue(i)
+		slice = append(slice, i)
+	}
+
+	_, err := suite.fifo.GetAll(&limit, &offset)
+	suite.EqualError(err, "Offset index out of bounds")
+	suite.Equal(slice, suite.fifo.slice)
+}
+
+// ***************************************************************************************
 // ** Run suite
 // ***************************************************************************************
 

--- a/fifo_queue_test.go
+++ b/fifo_queue_test.go
@@ -751,6 +751,110 @@ func (suite *FIFOTestSuite) TestSwapElements() {
 }
 
 // ***************************************************************************************
+// ** Move elements inside an empty queue
+// ***************************************************************************************
+func (suite *FIFOTestSuite) TestMoveEmptyQueue() {
+	const (
+		top  = 10
+		back = 1
+	)
+
+	suite.EqualError(suite.fifo.MoveFrontWithId(top), "Empty queue")
+	suite.EqualError(suite.fifo.MoveBackWithId(back), "Empty queue")
+}
+
+// ***************************************************************************************
+// ** Move elements to the front
+// ***************************************************************************************
+func (suite *FIFOTestSuite) TestMoveFront() {
+	const (
+		size = 10
+		top  = 4
+	)
+
+	for i := 0; i < size; i++ {
+		suite.fifo.Enqueue(i + 1)
+	}
+
+	result := []interface{}{5, 1, 2, 3, 4, 6, 7, 8, 9, 10}
+
+	suite.NoError(suite.fifo.MoveFrontWithId(top))
+	suite.Equal(result, suite.fifo.slice)
+}
+
+func (suite *FIFOTestSuite) TestMoveFrontOutOfBounds() {
+	const (
+		size = 10
+		top  = 10
+	)
+
+	for i := 0; i < size; i++ {
+		suite.fifo.Enqueue(i + 1)
+	}
+
+	suite.EqualError(suite.fifo.MoveFrontWithId(top), "Index is out of bounds")
+}
+
+func (suite *FIFOTestSuite) TestMoveFrontAlreadyInFront() {
+	const (
+		size = 10
+		top  = 0
+	)
+
+	for i := 0; i < size; i++ {
+		suite.fifo.Enqueue(i + 1)
+	}
+
+	suite.EqualError(suite.fifo.MoveFrontWithId(top), "Element already is in first position")
+}
+
+// ***************************************************************************************
+// ** Move elements to the back
+// ***************************************************************************************
+func (suite *FIFOTestSuite) TestMoveBack() {
+	const (
+		size = 10
+		back = 4
+	)
+
+	for i := 0; i < size; i++ {
+		suite.fifo.Enqueue(i + 1)
+	}
+
+	result := []interface{}{1, 2, 3, 4, 6, 7, 8, 9, 10, 5}
+
+	suite.NoError(suite.fifo.MoveBackWithId(back))
+	suite.Equal(result, suite.fifo.slice)
+}
+
+func (suite *FIFOTestSuite) TestMoveBackOutOfBounds() {
+	const (
+		size = 10
+		back = 10
+	)
+
+	for i := 0; i < size; i++ {
+		suite.fifo.Enqueue(i + 1)
+	}
+
+	suite.EqualError(suite.fifo.MoveBackWithId(back), "Index is out of bounds")
+	suite.Error(suite.fifo.MoveBackWithId(back))
+}
+
+func (suite *FIFOTestSuite) TestMoveBackAlreadyInBack() {
+	const (
+		size = 10
+		back = 9
+	)
+
+	for i := 0; i < size; i++ {
+		suite.fifo.Enqueue(i + 1)
+	}
+
+	suite.EqualError(suite.fifo.MoveBackWithId(back), "Element already is in last position")
+}
+
+// ***************************************************************************************
 // ** Run suite
 // ***************************************************************************************
 


### PR DESCRIPTION
Hey there, I've been using this library (great work btw! it's super simple to use) for a project and I wanted to share some features that I've created for the FIFO Queue.

1. `GetAll(limit, offset *int)` is a method that returns the underlying array, but has two arguments (limit and offset) to create a filtered slice from the original one.
2. `Swap(a int, b int)` is a method that swaps A with B and vice versa.
3. `MoveFrontWithId(index int)` & `MoveBackWithId(index int)` are two methods that let you change the position of a certain element to the front or the back.

I think they are very useful methods, although they could be very specifics to certain situations. Hope you like it!

Best,
Marcos.