### PR TITLE
Support passing context into DequeueOrWaitForNextElement

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -158,6 +158,38 @@ func main() {
 
 ```
 
+### Wait until an element gets enqueued with timeout
+[Live code - playground](https://play.golang.org/p/E3xdHcW5nJy)
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/enriquebris/goconcurrentqueue"
+)
+
+func main() {
+	var (
+		fifo = goconcurrentqueue.NewFIFO()
+		ctx, cancel = context.WithTimeout(context.Background(), 3*time.Second)
+	)
+	defer cancel()
+
+	fmt.Println("1 - Waiting for next enqueued element")
+	_, err := fifo.DequeueOrWaitForNextElementContext(ctx)
+    
+	if err != nil {
+		fmt.Printf("2 - Failed waiting for new element: %v\n", err)
+		return
+	}
+}
+
+```
+
 ### Dependency Inversion Principle using concurrent-safe queues
 
 *High level modules should not depend on low level modules. Both should depend on abstractions.* Robert C. Martin


### PR DESCRIPTION
This change adds the ability to pass a context into `DequeueOrWaitForNextElement` by introducing `DequeueOrWaitForNextElementContext`. Whenever the context is canceled, the method returns immediately.

Some background; when working in concurrent applications it is common to pass around a context that is canceled whenever the long-running process should exit. You can see libraries like [http natively support](https://golang.org/pkg/net/http/#NewRequestWithContext) context. I think it would make sense that these concurrent queues also support context passing.

For now I implemented this function only in the FIFO struct because I would like to get some feedback first. If we agree that this is something we want I can also implement the same in FixedFIFO.

I added a single test `TestContextCanceled`. It feels little, but i'm also not sure which other scenarios need to be tested. Let me know if you have ideas for other test cases.